### PR TITLE
replaced viewDidLoad() override

### DIFF
--- a/Magic 8 Ball/ViewController.swift
+++ b/Magic 8 Ball/ViewController.swift
@@ -12,7 +12,10 @@ class ViewController: UIViewController {
     
     let ballArray = [#imageLiteral(resourceName: "ball1.png"),#imageLiteral(resourceName: "ball2.png"),#imageLiteral(resourceName: "ball3.png"),#imageLiteral(resourceName: "ball4.png"),#imageLiteral(resourceName: "ball5.png")]
 
-
+    override func viewDidLoad() {
+       super.viewDidLoad()
+       // Do any additional setup after loading the view.
+    }
 
 }
 


### PR DESCRIPTION
The removal of `viewDidLoad()` override from the ViewController has created a course that won't run. This should be merged back in.